### PR TITLE
feat: update legacy login to return unique token

### DIFF
--- a/android/src/main/java/com/googleacm/GoogleAcmModule.kt
+++ b/android/src/main/java/com/googleacm/GoogleAcmModule.kt
@@ -32,6 +32,7 @@ import com.google.android.libraries.identity.googleid.GetGoogleIdOption
 import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
 import com.google.android.libraries.identity.googleid.GoogleIdTokenParsingException
 
+import com.google.android.gms.auth.GoogleAuthUtil
 import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions
 import com.google.android.gms.common.api.ApiException
@@ -48,6 +49,8 @@ class GoogleAcmModule(reactContext: ReactApplicationContext) :
   @Volatile
   private var legacySignInDeferred: CompletableDeferred<ReadableMap?>? = null
   private val legacySignInLock = Any()
+  @Volatile
+  private var lastLegacyIdToken: String? = null
 
   init {
     reactContext.addActivityEventListener(this)
@@ -107,7 +110,7 @@ class GoogleAcmModule(reactContext: ReactApplicationContext) :
       } catch (e: GetCredentialException) {
         Log.w("GoogleAcm", "Credential Manager failed, falling back to legacy sign-in", e)
         try {
-          val data = tryLegacySignIn(serverClientId, nonce)
+          val data = tryLegacySignIn(serverClientId)
           if (data != null) {
             promise.resolve(data)
           } else {
@@ -123,7 +126,7 @@ class GoogleAcmModule(reactContext: ReactApplicationContext) :
       } catch (e: Exception) {
         Log.e("GoogleAcm", "Unexpected error during sign-in", e)
         try {
-          val data = tryLegacySignIn(serverClientId, nonce)
+          val data = tryLegacySignIn(serverClientId)
           if (data != null) {
             promise.resolve(data)
           } else {
@@ -137,7 +140,7 @@ class GoogleAcmModule(reactContext: ReactApplicationContext) :
     }
   }
 
-  private suspend fun tryLegacySignIn(serverClientId: String, nonce: String = ""): ReadableMap? {
+  private suspend fun tryLegacySignIn(serverClientId: String): ReadableMap? {
     val activity = currentActivity
       ?: throw Exception("No activity available for legacy sign-in")
 
@@ -147,6 +150,13 @@ class GoogleAcmModule(reactContext: ReactApplicationContext) :
       .build()
 
     val client = GoogleSignIn.getClient(activity, gso)
+
+    try {
+      lastLegacyIdToken?.let {
+        GoogleAuthUtil.clearToken(reactApplicationContext, it)
+        lastLegacyIdToken = null
+      }
+    } catch (_: Exception) { }
 
     try {
       suspendCancellableCoroutine<Unit> { cont ->
@@ -200,6 +210,7 @@ class GoogleAcmModule(reactContext: ReactApplicationContext) :
       val idToken = account?.idToken
 
       if (idToken != null) {
+        lastLegacyIdToken = idToken
         Arguments.createMap().apply {
           putString("type", "google-signin")
           putString("id", account.id ?: "")

--- a/android/src/main/java/com/googleacm/GoogleAcmModule.kt
+++ b/android/src/main/java/com/googleacm/GoogleAcmModule.kt
@@ -25,6 +25,7 @@ import androidx.credentials.CredentialManager
 import androidx.credentials.ClearCredentialStateRequest
 import androidx.credentials.CustomCredential
 import androidx.credentials.GetCredentialRequest
+import androidx.credentials.exceptions.GetCredentialCancellationException
 
 
 import com.google.android.libraries.identity.googleid.GetGoogleIdOption
@@ -107,6 +108,11 @@ class GoogleAcmModule(reactContext: ReactApplicationContext) :
           promise.reject("ERROR", "Failed to parse credential response")
         }
       } catch (e: Exception) {
+        if (e is GetCredentialCancellationException) {
+          promise.reject("ERROR", "User cancelled")
+          return@launch
+        }
+
         Log.w("GoogleAcm", "Credential Manager failed, falling back to legacy sign-in", e)
         try {
           val data = tryLegacySignIn(serverClientId)

--- a/android/src/main/java/com/googleacm/GoogleAcmModule.kt
+++ b/android/src/main/java/com/googleacm/GoogleAcmModule.kt
@@ -13,9 +13,11 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 
 import android.content.Intent
+import android.os.Build
 import android.util.Log
 import android.app.Activity
 import androidx.credentials.CredentialManager
@@ -105,7 +107,7 @@ class GoogleAcmModule(reactContext: ReactApplicationContext) :
       } catch (e: GetCredentialException) {
         Log.w("GoogleAcm", "Credential Manager failed, falling back to legacy sign-in", e)
         try {
-          val data = tryLegacySignIn(serverClientId)
+          val data = tryLegacySignIn(serverClientId, nonce)
           if (data != null) {
             promise.resolve(data)
           } else {
@@ -121,7 +123,7 @@ class GoogleAcmModule(reactContext: ReactApplicationContext) :
       } catch (e: Exception) {
         Log.e("GoogleAcm", "Unexpected error during sign-in", e)
         try {
-          val data = tryLegacySignIn(serverClientId)
+          val data = tryLegacySignIn(serverClientId, nonce)
           if (data != null) {
             promise.resolve(data)
           } else {
@@ -135,7 +137,7 @@ class GoogleAcmModule(reactContext: ReactApplicationContext) :
     }
   }
 
-  private suspend fun tryLegacySignIn(serverClientId: String): ReadableMap? {
+  private suspend fun tryLegacySignIn(serverClientId: String, nonce: String = ""): ReadableMap? {
     val activity = currentActivity
       ?: throw Exception("No activity available for legacy sign-in")
 
@@ -157,6 +159,8 @@ class GoogleAcmModule(reactContext: ReactApplicationContext) :
         client.signOut().addOnCompleteListener { cont.resume(Unit) }
       }
     } catch (_: Exception) { }
+
+    delay(300)
 
     val deferred = CompletableDeferred<ReadableMap?>()
     synchronized(legacySignInLock) {
@@ -276,8 +280,17 @@ class GoogleAcmModule(reactContext: ReactApplicationContext) :
       throw Exception("Current activity is null, cannot sign out.")
     }
 
-    val credentialManager = CredentialManager.create(activity)
-    credentialManager.clearCredentialState(ClearCredentialStateRequest())
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+      try {
+        val credentialManager = CredentialManager.create(activity)
+        credentialManager.clearCredentialState(ClearCredentialStateRequest())
+      } catch (e: Throwable) {
+        Log.w("GoogleAcm", "clearCredentialState failed, will clear legacy sign-in state", e)
+      }
+    } else {
+      Log.d("GoogleAcm", "Skipping clearCredentialState on API ${Build.VERSION.SDK_INT}, using legacy sign-out only")
+    }
+
     try {
       val gso = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN).build()
       val client = GoogleSignIn.getClient(activity, gso)

--- a/android/src/main/java/com/googleacm/GoogleAcmModule.kt
+++ b/android/src/main/java/com/googleacm/GoogleAcmModule.kt
@@ -26,7 +26,6 @@ import androidx.credentials.ClearCredentialStateRequest
 import androidx.credentials.CustomCredential
 import androidx.credentials.GetCredentialRequest
 
-import androidx.credentials.exceptions.GetCredentialException
 
 import com.google.android.libraries.identity.googleid.GetGoogleIdOption
 import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
@@ -107,7 +106,7 @@ class GoogleAcmModule(reactContext: ReactApplicationContext) :
         } else {
           promise.reject("ERROR", "Failed to parse credential response")
         }
-      } catch (e: GetCredentialException) {
+      } catch (e: Exception) {
         Log.w("GoogleAcm", "Credential Manager failed, falling back to legacy sign-in", e)
         try {
           val data = tryLegacySignIn(serverClientId)
@@ -120,21 +119,8 @@ class GoogleAcmModule(reactContext: ReactApplicationContext) :
           Log.e("GoogleAcm", "Legacy sign-in also failed", legacyError)
           promise.reject(
             "ERROR",
-            "Credential Manager failed: ${e.message}; Legacy fallback also failed: ${legacyError.message}"
+            "Sign-in failed: ${e.message}; Legacy fallback also failed: ${legacyError.message}"
           )
-        }
-      } catch (e: Exception) {
-        Log.e("GoogleAcm", "Unexpected error during sign-in", e)
-        try {
-          val data = tryLegacySignIn(serverClientId)
-          if (data != null) {
-            promise.resolve(data)
-          } else {
-            promise.reject("ERROR", "Sign-in failed and legacy fallback returned no credential")
-          }
-        } catch (legacyError: Exception) {
-          Log.e("GoogleAcm", "Legacy sign-in also failed", legacyError)
-          promise.reject("ERROR", "Sign-in failed: ${e.message}; Legacy fallback also failed: ${legacyError.message}")
         }
       }
     }
@@ -291,34 +277,36 @@ class GoogleAcmModule(reactContext: ReactApplicationContext) :
       throw Exception("Current activity is null, cannot sign out.")
     }
 
+    var credentialManagerSuccess = false
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
       try {
         val credentialManager = CredentialManager.create(activity)
         credentialManager.clearCredentialState(ClearCredentialStateRequest())
+        credentialManagerSuccess = true
       } catch (e: Throwable) {
-        Log.w("GoogleAcm", "clearCredentialState failed, will clear legacy sign-in state", e)
+        Log.w("GoogleAcm", "clearCredentialState failed, falling back to legacy sign-out", e)
       }
-    } else {
-      Log.d("GoogleAcm", "Skipping clearCredentialState on API ${Build.VERSION.SDK_INT}, using legacy sign-out only")
     }
 
-    try {
-      lastLegacyIdToken?.let {
-        GoogleAuthUtil.clearToken(reactApplicationContext, it)
+    if (!credentialManagerSuccess) {
+      try {
+        lastLegacyIdToken?.let {
+          GoogleAuthUtil.clearToken(reactApplicationContext, it)
+        }
+      } catch (e: Exception) {
+        Log.w("GoogleAcm", "Failed to clear cached token", e)
       }
-    } catch (e: Exception) {
-      Log.w("GoogleAcm", "Failed to clear cached token", e)
-    }
-    lastLegacyIdToken = null
+      lastLegacyIdToken = null
 
-    try {
-      val gso = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN).build()
-      val client = GoogleSignIn.getClient(activity, gso)
-      suspendCancellableCoroutine<Unit> { cont ->
-        client.signOut().addOnCompleteListener { cont.resume(Unit) }
+      try {
+        val gso = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN).build()
+        val client = GoogleSignIn.getClient(activity, gso)
+        suspendCancellableCoroutine<Unit> { cont ->
+          client.signOut().addOnCompleteListener { cont.resume(Unit) }
+        }
+      } catch (e: Exception) {
+        Log.w("GoogleAcm", "Failed to clear legacy sign-in state", e)
       }
-    } catch (e: Exception) {
-      Log.w("GoogleAcm", "Failed to clear legacy sign-in state", e)
     }
   }
 

--- a/android/src/main/java/com/googleacm/GoogleAcmModule.kt
+++ b/android/src/main/java/com/googleacm/GoogleAcmModule.kt
@@ -303,6 +303,15 @@ class GoogleAcmModule(reactContext: ReactApplicationContext) :
     }
 
     try {
+      lastLegacyIdToken?.let {
+        GoogleAuthUtil.clearToken(reactApplicationContext, it)
+      }
+    } catch (e: Exception) {
+      Log.w("GoogleAcm", "Failed to clear cached token", e)
+    }
+    lastLegacyIdToken = null
+
+    try {
       val gso = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN).build()
       val client = GoogleSignIn.getClient(activity, gso)
       suspendCancellableCoroutine<Unit> { cont ->


### PR DESCRIPTION
## **Description**

## **Problem**
Currently legacy return same token for the period of 1 hour on every re-signin.

## **Solution**

* Skip legacy fallback when user cancels the Credential Manager prompt (GetCredentialCancellationException).
* To make the legacy sign in to return unique token
* Jira: https://consensyssoftware.atlassian.net/browse/TO-573

## Testing
Tested on emulators with two API levels:

API 34 — Pixel_5_Pro_API_34:

https://github.com/user-attachments/assets/2e5bdc23-8d74-4a51-bb03-8ba82c441cb6




API 27 — Nexus_API_27:

https://github.com/user-attachments/assets/747ad751-c39a-4b22-b119-294c19203c76

https://github.com/user-attachments/assets/43cd3157-a8bf-4623-809f-881d080208ad


https://github.com/user-attachments/assets/983db9c6-9145-4c86-a52c-3183554671b2




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit c869eec39ce71cbf328eb2b4f4946468a671fffc. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->